### PR TITLE
Add workflow to promote develop pushes to pull requests for the master branch

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+
 jobs:
   develop_to_master_promotion:
     runs-on: ubuntu-latest
@@ -11,6 +12,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: master
+          token: ${{ github.token }}
       - name: Reset promotion branch
         run: |
           git fetch origin develop:develop
@@ -18,4 +20,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
-          branch: develop-to-master
+          branch: develop
+          team-reviewers: "Consensus Dev"
+          token: ${{ github.token }}
+          title: "Promote develop to master"

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -1,0 +1,21 @@
+name: Promote develop to master
+
+on:
+  push:
+    branches:
+      - develop
+jobs:
+  develop_to_master_promotion:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: master
+      - name: Reset promotion branch
+        run: |
+          git fetch origin develop:develop
+          git reset --hard develop
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          branch: develop-to-master


### PR DESCRIPTION
This PR adds a workflow in `.github/workflows/promote.yaml` that helps streamline the promotion of PR-approved develop code to the master branch by creating a PR to merge develop into master. Then GitHub releases would ultimately send changes into production or send changes to where they need to be before our continuous delivery solution handles the rest of the work. Tested with [act cli](https://github.com/nektos/act) and a GitHub PAT. 

Also, we will want to build tests to run in `.github/workflows/pull-request.yaml` as these tests will be part of our check before PRs can be merged. 

I'll add us all for PAT access on the repo so you can use your own locally with workflow files:
```sh
act -s GITHUB_TOKEN=[insert token]
```

This needs a bit more work before merging. Going to make sure the workflow auto-populates our reviewers. Saving as a draft for now.

